### PR TITLE
WIP: Fix restoration crashes, Merge after #7 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Saved state restoration crash for views with auto-generated ids
+
 ## [2.0.0] - 2021-04-13
 ### Changed
 - Migration from jCenter to Maven Central 🎉

--- a/anko-constraint-layout/build.gradle
+++ b/anko-constraint-layout/build.gradle
@@ -25,9 +25,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.0.2'
 
-    // TODO Change to implementation
-    api 'androidx.constraintlayout:constraintlayout:1.1.3'
-    api "org.jetbrains.anko:anko-sdk15:0.10.8"
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation "org.jetbrains.anko:anko-sdk15:0.10.8"
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/anko-constraint-layout/src/main/java/io/github/ackeecz/ankoconstraintlayout/ViewIdGenerator.kt
+++ b/anko-constraint-layout/src/main/java/io/github/ackeecz/ankoconstraintlayout/ViewIdGenerator.kt
@@ -1,59 +1,22 @@
 package io.github.ackeecz.ankoconstraintlayout
 
-import android.os.Build
-import android.view.View
-import java.util.concurrent.atomic.AtomicInteger
-
+import androidx.core.view.ViewCompat
 
 /**
- * Starting with android version Jelly Bean (17), we can programmatically generate unique
- * ids for our views using generateViewId() method. [ViewIdGenerator] object backports this
- * functionality to pre-JB version as well. Implementation for pre-JB is copied from AOSP
- * source codes and mirrors post-JB implementation.
- *
- * View ids defined in xml layouts and ids.xml are always generated with ids higher than 0x00FFFFFF.
- * That gives us a lot of space for generating our own ids under this limit.
- *
- * Note: If another library uses the same approach for dynamic generation of ids by mirroring the
- * post-JB implementation, it is possible to have id conflicts because both this library and the
- * other library counts nextGeneratedId separately. In such case don't rely on automatic generation
- * of ids provided by this library and manually specify ids for all views that for any reason
- * need to have an unique id
- *
- * @author David Khol [david.khol@ackee.cz]
- * @since 25. 8. 2017
- **/
+ * Object used for generating new View ids. It provides a way to override the algorithm of id
+ * generation if needed.
+ */
 object ViewIdGenerator {
 
     /**
      * Users may set their own implementation of idGenerator to eliminate problem with multiple
-     * libraries using separate counters for generating new IDs
+     * libraries using separate counters for generating new IDs.
+     * It defaults to [ViewCompat.generateViewId].
      */
-    var idGeneratorImplementation: () -> Int = this::ourImplementation
+    var idGeneratorImplementation: () -> Int = ViewCompat::generateViewId
 
-
-    // generates a unique id every time this function is called
-    fun newId(): Int {
-        return idGeneratorImplementation()
-    }
-
-
-    private val nextIdGenerator = AtomicInteger(1)
-
-    fun ourImplementation(): Int {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            while (true) {
-                val result = nextIdGenerator.get()
-                // aapt-generated IDs have the high byte nonzero; clamp to the range under that.
-                var newValue = result + 1
-                if (newValue > 0x00FFFFFF)
-                    newValue = 1 // Roll over to 1, not 0.
-                if (nextIdGenerator.compareAndSet(result, newValue)) {
-                    return result
-                }
-            }
-        } else {
-            return View.generateViewId()
-        }
-    }
+    /**
+     * Generates a unique id every time this function is called
+     */
+    fun newId() = idGeneratorImplementation()
 }

--- a/anko-constraint-layout/src/main/java/io/github/ackeecz/ankoconstraintlayout/_ConstraintLayout.kt
+++ b/anko-constraint-layout/src/main/java/io/github/ackeecz/ankoconstraintlayout/_ConstraintLayout.kt
@@ -50,6 +50,11 @@ open class _ConstraintLayout(ctx: Context) : ConstraintLayout(ctx) {
         // being rendered might change.)
         if (generateIds) {
             if (view.id == View.NO_ID) {
+                // Saved state has to be disabled for those generated ids because they will
+                // change during next view recreation. Framework then could try to deliver incorrect
+                // saved state object of other view, which had assigned this new id in the previous
+                // view hierarchy and it can crash the application.
+                view.isSaveEnabled = false
                 view.id = ViewIdGenerator.newId()
             }
         }

--- a/lib.properties
+++ b/lib.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 VERSION_CODE=1
 GROUP=io.github.ackeecz
 SITE_URL=https://github.com/AckeeCZ/anko-constraint-layout


### PR DESCRIPTION
Merge after #7 

When view added to constraint layout does not have an ID, we generate one and assign it. The problem is that during view saved state restoration, it can (and most probably will) have a different generated ID assigned and this ID could have been assigned to some other view of other class type in the previous view hierarchy before view destruction and recreation. If this happens, app will crash because it will basically try to access the saved state which does not belong to this view. Solution is to disable saved state for all views with auto-generated IDs. State will not be even saved for them (it will be only saved for views with explicitly declared ids).