### PR TITLE
🐛 Fix restoration crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Saved state restoration crash for views with auto-generated ids caused by a bug in View class
 
 ## [2.0.1] - 2021-04-13
 ### Fixed

--- a/anko-constraint-layout/build.gradle
+++ b/anko-constraint-layout/build.gradle
@@ -23,7 +23,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "androidx.core:core-ktx:1.3.2"
 
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "org.jetbrains.anko:anko-sdk15:0.10.8"


### PR DESCRIPTION
isSavedState is not respected in the View's dispatchRestoreInstanceState implementation. This commit workarounds this issue by a custom dispatching logic in _ConstraintLayout.

More info in the code comments.